### PR TITLE
Change the name for the master branch testing on 4.7

### DIFF
--- a/examples/gpu-operator.yml
+++ b/examples/gpu-operator.yml
@@ -21,8 +21,8 @@ matrices:
         operator_version: master
 
       1|OpenShift 4.7:
-      - branch: release-next
-        test_name: gpu-operator-e2e
+      - branch: release-4.7
+        test_name: gpu-operator-e2e-master
         operator_version: master
 
       - branch: release-4.7


### PR DESCRIPTION
Test was moved in https://github.com/openshift/release/pull/17195 from
`release-next` to `release-4.7`.