### PR TITLE
Add "matrix_benchmarks" command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,6 +74,16 @@ static:
 	cp -rv static/* output/
 
 .PHONY: static
+
+#
+
+matrix_benchmarks:
+	go run cmd/main.go --debug matrix_benchmarks \
+           --config-file examples/gpu-operator.yml \
+           --output-dir output/matrix_benchmarks
+
+.PHONY: matrix_benchmarking
+
 #
 
 build:

--- a/api/matrix/v1/spec.go
+++ b/api/matrix/v1/spec.go
@@ -46,6 +46,8 @@ type TestResult struct {
 	/* *** */
 	TestSpec *TestSpec
 
+	ToolboxSteps []string
+
 	ToolboxStepsResults []ToolboxStepResult
 
 	/* *** */

--- a/cmd/daily_matrix/daily_matrix.go
+++ b/cmd/daily_matrix/daily_matrix.go
@@ -121,6 +121,8 @@ func daily_matrixWrapper(c *cli.Context, f *Flags) error {
 		return fmt.Errorf("error fetching the matrix results: %v", err)
 	}
 
+	populate.PopulateTestStepLogs(matricesSpec)
+
 	currentTime := time.Now()
 	generation_date := currentTime.Format("2006-01-02 15h04")
 

--- a/cmd/daily_matrix/daily_matrix.go
+++ b/cmd/daily_matrix/daily_matrix.go
@@ -9,11 +9,11 @@ import (
 
 	"github.com/sirupsen/logrus"
 	cli "github.com/urfave/cli/v2"
-	"github.com/openshift-psap/ci-dashboard/pkg/artifacts"
-	"github.com/openshift-psap/ci-dashboard/pkg/config"
 
-	v1 "github.com/openshift-psap/ci-dashboard/api/matrix/v1"
+	"github.com/openshift-psap/ci-dashboard/pkg/config"
+	"github.com/openshift-psap/ci-dashboard/pkg/populate"
 	matrix_tpl "github.com/openshift-psap/ci-dashboard/pkg/template/matrix"
+
 )
 
 const (
@@ -111,140 +111,13 @@ func saveGeneratedHtml(generated_html []byte, f *Flags) error {
 	return nil
 }
 
-func populateTestFromFinished(test *v1.TestResult, test_finished artifacts.ArtifactResult) error {
-	if test_finished.Json["passed"] != nil {
-		test.Passed = test_finished.Json["passed"].(bool)
-	} else {
-		test.Passed = false
-	}
-	if test_finished.Json["result"] != nil {
-		test.Result = test_finished.Json["result"].(string)
-	} else {
-		test.Result = "N/A"
-	}
-	if test_finished.Json["timestamp"] != nil {
-		ts := test_finished.Json["timestamp"].(float64)
-		test.FinishDate = time.Unix(int64(ts), 0).Format("2006-01-02 15:04")
-	} else {
-		test.FinishDate = "N/A"
-	}
-	return nil
-}
-
-func populateTestFromStepFinished(test *v1.TestResult, step_test_finished artifacts.ArtifactResult) error {
-	test.StepExecuted = true
-	if step_test_finished.Json["passed"] != nil {
-		test.StepPassed = step_test_finished.Json["passed"].(bool)
-	} else {
-		test.StepPassed = false
-	}
-	if step_test_finished.Json["result"] != nil {
-		test.StepResult = step_test_finished.Json["result"].(string)
-	} else {
-		test.StepResult = "N/A"
-	}
-
-	return nil
-}
-
-func populateTestFromToolboxLogs(test *v1.TestResult, toolbox_logs map[string]artifacts.JsonArray) error {
-	test.Ok = 0
-	test.Failures = 0
-	test.Ignored = 0
-
-	for toolbox_step_name, toolbox_step_json := range toolbox_logs {
-		stats := toolbox_step_json[len(toolbox_step_json)-1].(map[string]interface{})["stats"].(map[string]interface{})["localhost"].(map[string]interface{})
-		ok := int(stats["ok"].(float64))
-		failures := int(stats["failures"].(float64))
-		ignored := int(stats["ignored"].(float64))
-		log.Debugf("Step %s: ok %d, failures %d, ignored %d", toolbox_step_name, ok, failures, ignored)
-
-		test.ToolboxStepsResults = append(test.ToolboxStepsResults,
-			v1.ToolboxStepResult{toolbox_step_name, ok, failures, ignored}, )
-
-		test.Ok += ok
-		test.Failures += failures
-		test.Ignored += ignored
-	}
-	log.Debugf("Test: ok %d, failures %d, ignored %d", test.Ok, test.Failures, test.Ignored)
-
-	return nil
-}
-
-func populateTestMatrices(matricesSpec *v1.MatricesSpec, test_history int) error {
-	for matrix_name, test_matrix := range matricesSpec.Matrices {
-		log.Printf("* %s: %s\n", matrix_name, test_matrix.Description)
-		for test_group, tests := range test_matrix.Tests {
-			for test_idx := range tests {
-				test := &tests[test_idx]
-				var branch string
-				if test.Variant != "" {
-					branch = fmt.Sprintf("%s-%s", test.Branch, test.Variant)
-				} else {
-					branch = test.Branch
-				}
-
-				test.ProwName = fmt.Sprintf("%s-%s-%s", test_matrix.ProwConfig, branch, test.TestName)
-				test.TestGroup = test_group
-
-				// override matricesSpec.TestHistory if we received a flag value
-				if test_history >= 0 {
-					matricesSpec.TestHistory = test_history
-				}
-
-				test_build_ids, old_tests, err := artifacts.FetchLastNTestResults(&test_matrix, matrix_name, test.ProwName, matricesSpec.TestHistory,
-					"finished.json", artifacts.TypeJson)
-				if err != nil {
-					return fmt.Errorf("Failed to fetch the last %d test results for %s: %v", matricesSpec.TestHistory, test.ProwName, err)
-				}
-				for _, old_test_build_id := range test_build_ids {
-					old_test_finished := old_tests[old_test_build_id]
-					old_test := v1.TestResult{TestSpec: test}
-					old_test.BuildId = old_test_build_id
-					test.OldTests = append(test.OldTests, &old_test)
-
-					if err = populateTestFromFinished(&old_test, old_test_finished); err != nil {
-						log.Warningf("Failed to store the last results of test %s/%s: %v",
-							test.ProwName, old_test_build_id, err)
-						continue
-					}
-
-					old_test_toolbox_logs, err := artifacts.FetchTestToolboxLogs(&test_matrix, test, old_test_build_id)
-
-					if err = populateTestFromToolboxLogs(&old_test, old_test_toolbox_logs); err != nil {
-						log.Warningf("Failed to get the toolbox step logs of the test %s/%s: %v", test.ProwName, old_test_build_id, err)
-					}
-
-					if old_test.Passed {
-						continue
-					}
-					step_old_test_finished, err := artifacts.FetchTestStepResult(&test_matrix, test, old_test_build_id, "finished.json", artifacts.TypeJson)
-					if err != nil {
-						// if finished.json can be parsed as an HTML file, the file certainly does'nt exist --> do not warn about it
-						_, err_json_as_html := artifacts.FetchTestStepResult(&test_matrix, test, old_test_build_id, "finished.json", artifacts.TypeHtml)
-						if err_json_as_html != nil {
-							log.Warningf("Failed to fetch the results of test step %s/%s: %v",
-								test.ProwName, old_test_build_id, err)
-						}
-					}
-					if err = populateTestFromStepFinished(&old_test, step_old_test_finished); err != nil {
-						log.Warningf("Failed to store the results of test step %s/%s: %v", test.ProwName, old_test_build_id, err)
-					}
-				}
-			}
-		}
-	}
-
-	return nil
-}
-
 func daily_matrixWrapper(c *cli.Context, f *Flags) error {
 	matricesSpec, err := config.ParseMatricesConfigFile(f.ConfigFile)
 	if err != nil {
 		return fmt.Errorf("error parsing config file: %v", err)
 	}
 
-	if err = populateTestMatrices(matricesSpec, f.TestHistory); err != nil {
+	if err = populate.PopulateTestMatrices(matricesSpec, f.TestHistory); err != nil {
 		return fmt.Errorf("error fetching the matrix results: %v", err)
 	}
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -4,6 +4,7 @@ import (
 	"os"
 
 	"github.com/openshift-psap/ci-dashboard/cmd/daily_matrix"
+	"github.com/openshift-psap/ci-dashboard/cmd/matrix_benchmarks"
 	"github.com/openshift-psap/ci-dashboard/pkg/artifacts"
 	"github.com/openshift-psap/ci-dashboard/pkg/config"
 	log "github.com/sirupsen/logrus"
@@ -38,6 +39,7 @@ func main() {
 
 	app.Commands = []*cli.Command{
 		daily_matrix.BuildCommand(),
+		matrix_benchmarks.BuildCommand(),
 	}
 
 	// Set log-level for all subcommands

--- a/cmd/matrix_benchmarks/fetch.go
+++ b/cmd/matrix_benchmarks/fetch.go
@@ -1,0 +1,40 @@
+package matrix_benchmarks
+
+import (
+	"fmt"
+	"strings"
+
+	v1 "github.com/openshift-psap/ci-dashboard/api/matrix/v1"
+	"github.com/openshift-psap/ci-dashboard/pkg/artifacts"
+)
+
+func FetchGPUBurnLogs(test_matrix *v1.MatrixSpec, test_result *v1.TestResult, build_id string) (string, error) {
+	test_spec := test_result.TestSpec
+	for _, step := range test_result.ToolboxStepsResults {
+		if ! strings.Contains(step.Name, "_run_gpu_burn") {
+			continue
+		}
+		html_gpu_burn_files, err := artifacts.FetchTestStepResult(test_matrix, test_spec, build_id, fmt.Sprintf("artifacts/%s/", step.Name), artifacts.TypeHtml)
+		if err != nil {
+			return "", err
+		}
+
+		gpu_burn_files, err := artifacts.ListFilesInDirectory(html_gpu_burn_files.Html, false, true)
+		if err != nil {
+			return "", err
+		}
+		log.Debugf("==> %s", gpu_burn_files)
+		for _, filename := range gpu_burn_files {
+			if !(strings.HasPrefix(filename, "gpu_burn.") && strings.HasSuffix(filename, ".log")) {
+				continue
+			}
+			gpu_burn_logs, err := artifacts.FetchTestStepResult(test_matrix, test_spec, build_id, fmt.Sprintf("artifacts/%s/%s", step.Name, filename), artifacts.TypeBytes)
+			if err != nil {
+				return "", err
+			}
+			return string(gpu_burn_logs.Bytes), nil
+		}
+	}
+
+	return "", nil
+}

--- a/cmd/matrix_benchmarks/fetch.go
+++ b/cmd/matrix_benchmarks/fetch.go
@@ -10,11 +10,11 @@ import (
 
 func FetchGPUBurnLogs(test_matrix *v1.MatrixSpec, test_result *v1.TestResult, build_id string) (string, error) {
 	test_spec := test_result.TestSpec
-	for _, step := range test_result.ToolboxStepsResults {
-		if ! strings.Contains(step.Name, "_run_gpu_burn") {
+	for _, step_name := range test_result.ToolboxSteps {
+		if ! strings.Contains(step_name, "_run_gpu_burn") {
 			continue
 		}
-		html_gpu_burn_files, err := artifacts.FetchTestStepResult(test_matrix, test_spec, build_id, fmt.Sprintf("artifacts/%s/", step.Name), artifacts.TypeHtml)
+		html_gpu_burn_files, err := artifacts.FetchTestStepResult(test_matrix, test_spec, build_id, fmt.Sprintf("artifacts/%s/", step_name), artifacts.TypeHtml)
 		if err != nil {
 			return "", err
 		}
@@ -28,7 +28,7 @@ func FetchGPUBurnLogs(test_matrix *v1.MatrixSpec, test_result *v1.TestResult, bu
 			if !(strings.HasPrefix(filename, "gpu_burn.") && strings.HasSuffix(filename, ".log")) {
 				continue
 			}
-			gpu_burn_logs, err := artifacts.FetchTestStepResult(test_matrix, test_spec, build_id, fmt.Sprintf("artifacts/%s/%s", step.Name, filename), artifacts.TypeBytes)
+			gpu_burn_logs, err := artifacts.FetchTestStepResult(test_matrix, test_spec, build_id, fmt.Sprintf("artifacts/%s/%s", step_name, filename), artifacts.TypeBytes)
 			if err != nil {
 				return "", err
 			}

--- a/cmd/matrix_benchmarks/matrix_benchmarks.go
+++ b/cmd/matrix_benchmarks/matrix_benchmarks.go
@@ -1,0 +1,127 @@
+package matrix_benchmarks
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+
+	"github.com/sirupsen/logrus"
+	cli "github.com/urfave/cli/v2"
+	"github.com/openshift-psap/ci-dashboard/pkg/config"
+	"github.com/openshift-psap/ci-dashboard/pkg/populate"
+)
+
+const (
+	DefaultConfigFile  = "examples/gpu-operator.yml"
+	DefaultOutputDir = "output/matrix_benchmarking/"
+	DefaultTestHistory = -1
+)
+
+var log = logrus.New()
+
+func GetLogger() *logrus.Logger {
+	return log
+}
+
+type Flags struct {
+	ConfigFile string
+	OutputDir string
+	TestHistory int
+}
+
+type Context struct {
+	*cli.Context
+	Flags *Flags
+}
+
+func BuildCommand() *cli.Command {
+	// Create a flags struct to hold our flags
+	matrix_benchFlags := Flags{}
+
+	// Create the 'matrix_bench' command
+	matrix_bench := cli.Command{}
+	matrix_bench.Name = "matrix_benchmarks"
+	matrix_bench.Usage = "Generate MatrixBenchmarking results from Prow test artifacts"
+	matrix_bench.Action = func(c *cli.Context) error {
+		return matrix_benchWrapper(c, &matrix_benchFlags)
+	}
+
+	// Setup the flags for this command
+	matrix_bench.Flags = []cli.Flag{
+		&cli.StringFlag{
+			Name:        "config-file",
+			Aliases:     []string{"c"},
+			Usage:       "Configuration file to use for fetching the Prow results",
+			Destination: &matrix_benchFlags.ConfigFile,
+			Value:       DefaultConfigFile,
+			EnvVars:     []string{"CI_DASHBOARD_MATRIX_BENCH_CONFIG_FILE"},
+		},
+		&cli.StringFlag{
+			Name:        "output-dir",
+			Aliases:     []string{"o"},
+			Usage:       "Output directory where the generated MatrixBenchmarking results will be stored",
+			Destination: &matrix_benchFlags.OutputDir,
+			Value:       DefaultOutputDir,
+			EnvVars:     []string{"CI_DASHBOARD_MATRIX_BENCH_OUTPUT_FILE"},
+		},
+		&cli.IntFlag{
+			Name:        "test-history",
+			Aliases:     []string{"th"},
+			Usage:       "Number of tests to fetch",
+			Destination: &matrix_benchFlags.TestHistory,
+			Value:       DefaultTestHistory,
+			EnvVars:     []string{"CI_DASHBOARD_MATRIX_BENCH_TEST_HISTORY"},
+		},
+	}
+
+	return &matrix_bench
+}
+
+
+func matrix_benchWrapper(c *cli.Context, f *Flags) error {
+	matrices_spec, err := config.ParseMatricesConfigFile(f.ConfigFile)
+	if err != nil {
+		return fmt.Errorf("error parsing config file: %v", err)
+	}
+
+	if err = populate.PopulateTestMatrices(matrices_spec, f.TestHistory); err != nil {
+		return fmt.Errorf("error fetching the matrix results: %v", err)
+	}
+
+	//current_time := time.Now()
+	//generation_date := current_time.Format("2006-01-02 15h04")
+
+	for _, test_matrix := range matrices_spec.Matrices {
+		for _, tests := range test_matrix.Tests {
+			for test_idx := range tests {
+				for _, test_result := range tests[test_idx].OldTests {
+					FetchGPUBurnLogs(&test_matrix, test_result, test_result.BuildId)
+
+					gpu_burn_logs, err := FetchGPUBurnLogs(&test_matrix, test_result, test_result.BuildId)
+
+					if err != nil {
+						log.Warningf("Failed to fetch the GPU burn logs of the test %s/%s: %v", test_result.TestSpec.ProwName, test_result.BuildId, err)
+					}
+
+					if gpu_burn_logs == ""{
+						log.Warningf("Could not find GPU burn logs for the test %s/%s", test_result.TestSpec.ProwName, test_result.BuildId)
+						continue
+					}
+					dest_dir := fmt.Sprintf("%s/%s/%s/gpu-burn/", f.OutputDir, test_result.TestSpec.ProwName, test_result.BuildId)
+					err = os.MkdirAll(dest_dir, os.ModePerm)
+					if err != nil {
+						return fmt.Errorf("Failed to create output directory %s: %v", f.OutputDir, err)
+					}
+
+					dest_fname := dest_dir + "/pod.log"
+					err = ioutil.WriteFile(dest_fname, []byte(gpu_burn_logs), 0644)
+					if err != nil {
+						return fmt.Errorf("Failed to write into output file at %s: %v", dest_fname, err)
+					}
+				}
+			}
+		}
+	}
+
+	return nil
+}

--- a/pkg/populate/populate.go
+++ b/pkg/populate/populate.go
@@ -1,0 +1,141 @@
+package populate
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	"github.com/openshift-psap/ci-dashboard/pkg/artifacts"
+
+	v1 "github.com/openshift-psap/ci-dashboard/api/matrix/v1"
+)
+
+var log = logrus.New()
+
+func PopulateTestFromFinished(test *v1.TestResult, test_finished artifacts.ArtifactResult) error {
+	if test_finished.Json["passed"] != nil {
+		test.Passed = test_finished.Json["passed"].(bool)
+	} else {
+		test.Passed = false
+	}
+	if test_finished.Json["result"] != nil {
+		test.Result = test_finished.Json["result"].(string)
+	} else {
+		test.Result = "N/A"
+	}
+	if test_finished.Json["timestamp"] != nil {
+		ts := test_finished.Json["timestamp"].(float64)
+		test.FinishDate = time.Unix(int64(ts), 0).Format("2006-01-02 15:04")
+	} else {
+		test.FinishDate = "N/A"
+	}
+	return nil
+}
+
+func PopulateTestFromStepFinished(test *v1.TestResult, step_test_finished artifacts.ArtifactResult) error {
+	test.StepExecuted = true
+	if step_test_finished.Json["passed"] != nil {
+		test.StepPassed = step_test_finished.Json["passed"].(bool)
+	} else {
+		test.StepPassed = false
+	}
+	if step_test_finished.Json["result"] != nil {
+		test.StepResult = step_test_finished.Json["result"].(string)
+	} else {
+		test.StepResult = "N/A"
+	}
+
+	return nil
+}
+
+func PopulateTestFromToolboxLogs(test *v1.TestResult, toolbox_logs map[string]artifacts.JsonArray) error {
+	test.Ok = 0
+	test.Failures = 0
+	test.Ignored = 0
+
+	for toolbox_step_name, toolbox_step_json := range toolbox_logs {
+
+		stats := toolbox_step_json[len(toolbox_step_json)-1].(map[string]interface{})["stats"].(map[string]interface{})["localhost"].(map[string]interface{})
+		ok := int(stats["ok"].(float64))
+		failures := int(stats["failures"].(float64))
+		ignored := int(stats["ignored"].(float64))
+		log.Debugf("Step %s: ok %d, failures %d, ignored %d", toolbox_step_name, ok, failures, ignored)
+
+		test.ToolboxStepsResults = append(test.ToolboxStepsResults,
+			v1.ToolboxStepResult{Name: toolbox_step_name, Ok: ok, Failures: failures, Ignored: ignored}, )
+
+		test.Ok += ok
+		test.Failures += failures
+		test.Ignored += ignored
+	}
+	log.Debugf("Test: ok %d, failures %d, ignored %d", test.Ok, test.Failures, test.Ignored)
+
+	return nil
+}
+
+func PopulateTestMatrices(matricesSpec *v1.MatricesSpec, test_history int) error {
+	for matrix_name, test_matrix := range matricesSpec.Matrices {
+		log.Printf("* %s: %s\n", matrix_name, test_matrix.Description)
+		for test_group, tests := range test_matrix.Tests {
+			for test_idx := range tests {
+				test := &tests[test_idx]
+				var branch string
+				if test.Variant != "" {
+					branch = fmt.Sprintf("%s-%s", test.Branch, test.Variant)
+				} else {
+					branch = test.Branch
+				}
+
+				test.ProwName = fmt.Sprintf("%s-%s-%s", test_matrix.ProwConfig, branch, test.TestName)
+				test.TestGroup = test_group
+
+				// override matricesSpec.TestHistory if we received a flag value
+				if test_history >= 0 {
+					matricesSpec.TestHistory = test_history
+				}
+
+				test_build_ids, old_tests, err := artifacts.FetchLastNTestResults(&test_matrix, matrix_name, test.ProwName, matricesSpec.TestHistory,
+					"finished.json", artifacts.TypeJson)
+				if err != nil {
+					return fmt.Errorf("Failed to fetch the last %d test results for %s: %v", matricesSpec.TestHistory, test.ProwName, err)
+				}
+				for _, old_test_build_id := range test_build_ids {
+					old_test_finished := old_tests[old_test_build_id]
+					old_test := v1.TestResult{TestSpec: test}
+					old_test.BuildId = old_test_build_id
+					test.OldTests = append(test.OldTests, &old_test)
+
+					if err = PopulateTestFromFinished(&old_test, old_test_finished); err != nil {
+						log.Warningf("Failed to store the last results of test %s/%s: %v",
+							test.ProwName, old_test_build_id, err)
+						continue
+					}
+
+					old_test_toolbox_logs, err := artifacts.FetchTestToolboxLogs(&test_matrix, test, old_test_build_id)
+
+					if err = PopulateTestFromToolboxLogs(&old_test, old_test_toolbox_logs); err != nil {
+						log.Warningf("Failed to get the toolbox step logs of the test %s/%s: %v", test.ProwName, old_test_build_id, err)
+					}
+
+					if old_test.Passed {
+						continue
+					}
+					step_old_test_finished, err := artifacts.FetchTestStepResult(&test_matrix, test, old_test_build_id, "finished.json", artifacts.TypeJson)
+					if err != nil {
+						// if finished.json can be parsed as an HTML file, the file certainly does'nt exist --> do not warn about it
+						_, err_json_as_html := artifacts.FetchTestStepResult(&test_matrix, test, old_test_build_id, "finished.json", artifacts.TypeHtml)
+						if err_json_as_html != nil {
+							log.Warningf("Failed to fetch the results of test step %s/%s: %v",
+								test.ProwName, old_test_build_id, err)
+						}
+					}
+					if err = PopulateTestFromStepFinished(&old_test, step_old_test_finished); err != nil {
+						log.Warningf("Failed to store the results of test step %s/%s: %v", test.ProwName, old_test_build_id, err)
+					}
+				}
+			}
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
This PR adds a "matrix_benchmarks" command to the `ci-dashboard`.

This new commands generate output  files (in `output/matrix_benchmarks/`) properly structured for parsing&plotting with the MatrixBenchmark tool (see this [PR](https://gitlab.com/kpouget_psap/matrix_benchmark/-/merge_requests/2))

Here is an example of the current plot done by the MatrixBenchmark, via the interactive interface:
![image](https://user-images.githubusercontent.com/7559202/127470663-5a9bb1b0-1e70-4fdd-932f-d14351a2b29b.png)
