### PR TITLE
Fetch Ansible steps logs and parse OK/Failed/Ignored task count + other improvements

### DIFF
--- a/.github/workflows/test_generate_matrix_page.yml
+++ b/.github/workflows/test_generate_matrix_page.yml
@@ -15,7 +15,6 @@ jobs:
 
       - name: Generate the test matrix 🔧
         run: |
-          sed -i 's/nb_test_history:.*/nb_test_history: 2/' examples/gpu-operator.yml
-          sed -i 's/nb_test_history:.*/nb_test_history: 2/' examples/sro.yml
+          export CI_DASHBOARD_DAILYMATRIX_TEST_HISTORY=3
           make generate_daily_matrix
           make static

--- a/api/matrix/v1/spec.go
+++ b/api/matrix/v1/spec.go
@@ -67,8 +67,6 @@ type TestSpec struct {
 	TestGroup string
 
 	OldTests []*TestResult
-
-	TestResult
 }
 
 type MatrixSpec struct {

--- a/api/matrix/v1/spec.go
+++ b/api/matrix/v1/spec.go
@@ -60,6 +60,7 @@ type TestSpec struct {
 	Branch string          `json:"branch,omitempty"`
 	OperatorVersion string `json:"operator_version,omitempty"`
 	Variant string         `json:"variant"`
+	ProwStep string        `json:"prow_step,omitempty"`
 
 	/* *** */
 

--- a/api/matrix/v1/spec.go
+++ b/api/matrix/v1/spec.go
@@ -26,6 +26,14 @@ type MatricesSpec struct {
 	Matrices map[string]MatrixSpec `json:"matrices,omitempty"`
 }
 
+type ToolboxStepResult struct {
+	Name string
+
+	Ok int
+	Failures int
+	Ignored int
+}
+
 type TestResult struct {
 	BuildId string
 	Passed bool
@@ -37,6 +45,14 @@ type TestResult struct {
 	StepResult string
 	/* *** */
 	TestSpec *TestSpec
+
+	ToolboxStepsResults []ToolboxStepResult
+
+	/* *** */
+
+	Ok int
+	Failures int
+	Ignored int
 }
 
 type TestSpec struct {

--- a/api/matrix/v1/spec.go
+++ b/api/matrix/v1/spec.go
@@ -22,7 +22,7 @@ const Version = "v1"
 type MatricesSpec struct {
 	Version string                 `json:"version"`
 	Description string             `json:"description,omitempty"`
-	NbTestHistory int              `json:"nb_test_history"`
+	TestHistory int              `json:"test_history"`
 	Matrices map[string]MatrixSpec `json:"matrices,omitempty"`
 }
 

--- a/cmd/daily_matrix/daily_matrix.go
+++ b/cmd/daily_matrix/daily_matrix.go
@@ -95,17 +95,17 @@ func BuildCommand() *cli.Command {
 func saveGeneratedHtml(generated_html []byte, f *Flags) error {
 	output_dir, err := filepath.Abs(filepath.Dir(f.OutputFile))
     if err != nil {
-		return fmt.Errorf("Failed to get cache directory for %s: %v", f.OutputFile, err)
+		return fmt.Errorf("Failed to get output directory for %s: %v", f.OutputFile, err)
     }
 
 	err = os.MkdirAll(output_dir, os.ModePerm)
 	if err != nil {
-		return fmt.Errorf("Failed to create cache directory %s: %v", output_dir, err)
+		return fmt.Errorf("Failed to create output directory %s: %v", output_dir, err)
     }
 
 	err = ioutil.WriteFile(f.OutputFile, generated_html, 0644)
 	if err != nil {
-		return fmt.Errorf("Failed to write into cache file at %s: %v", f.OutputFile, err)
+		return fmt.Errorf("Failed to write into output file at %s: %v", f.OutputFile, err)
 	}
 
 	return nil

--- a/examples/gpu-operator.yml
+++ b/examples/gpu-operator.yml
@@ -38,11 +38,13 @@ matrices:
         test_name: gpu-operator-e2e-upgrade
         operator_version: master
         variant: upgrade
+        prow_step: 2-postupgrade-gpu-operator-validate-deployment
 
       - branch: release-4.7
         test_name: gpu-operator-e2e-upgrade-170
         operator_version: 1.7.0
         variant: upgrade
+        prow_step: 2-postupgrade-gpu-operator-validate-deployment
 
       2_460|OpenShift 4.6:
       - branch: release-4.6

--- a/examples/gpu-operator.yml
+++ b/examples/gpu-operator.yml
@@ -1,6 +1,6 @@
 version: v1
 description: GPU Operator Test Matrix
-nb_test_history: 15
+test_history: 15
 matrices:
   nightlies:
     description: Red Hat OpenShift Nightlies

--- a/examples/nfd.yml
+++ b/examples/nfd.yml
@@ -1,6 +1,6 @@
 version: v1
 description: Node Feature Discovery Operator Test Matrix
-nb_test_history: 15
+test_history: 15
 matrices:
   nightlies:
     description: Red Hat OpenShift Nightlies

--- a/examples/nto.yml
+++ b/examples/nto.yml
@@ -1,6 +1,6 @@
 version: v1
 description: Node Tuning Operator Test Matrix
-nb_test_history: 15
+test_history: 15
 matrices:
   nightlies:
     description: Red Hat OpenShift Nightlies

--- a/examples/sro.yml
+++ b/examples/sro.yml
@@ -1,6 +1,6 @@
 version: v1
 description: Special Resource Operator Test Matrix
-nb_test_history: 15
+test_history: 15
 matrices:
   nightlies:
     description: Red Hat OpenShift Nightlies

--- a/pkg/artifacts/fetch.go
+++ b/pkg/artifacts/fetch.go
@@ -34,12 +34,12 @@ type ArtifactResult struct {
 type JsonResult map[string]interface{}
 type JsonArray []interface{}
 
-func fetchRemoveFromCache(test_matrix v1.MatrixSpec, path string) error {
+func fetchRemoveFromCache(test_matrix *v1.MatrixSpec, path string) error {
 	cache_path := fmt.Sprintf("%s/%s", test_matrix.ArtifactsCache, path)
 	return os.Remove(cache_path)
 }
 
-func fetchArtifact(test_matrix v1.MatrixSpec, path string) ([]byte, error) {
+func fetchArtifact(test_matrix *v1.MatrixSpec, path string) ([]byte, error) {
 	cache_path := fmt.Sprintf("%s/%s", test_matrix.ArtifactsCache, path)
 	artifact_url := fmt.Sprintf("%s/%s", test_matrix.ArtifactsURL, path)
 
@@ -84,7 +84,7 @@ func fetchArtifact(test_matrix v1.MatrixSpec, path string) ([]byte, error) {
 	return content, nil
 }
 
-func fetchHtmlArtifact(test_matrix v1.MatrixSpec, path string) (*goquery.Document, error) {
+func fetchHtmlArtifact(test_matrix *v1.MatrixSpec, path string) (*goquery.Document, error) {
 	content, err := fetchArtifact(test_matrix, path)
 	if err != nil {
 		return nil, err
@@ -98,7 +98,7 @@ func fetchHtmlArtifact(test_matrix v1.MatrixSpec, path string) (*goquery.Documen
 	return doc, nil
 }
 
-func fetchJsonArtifact(test_matrix v1.MatrixSpec, path string) (JsonResult, error){
+func fetchJsonArtifact(test_matrix *v1.MatrixSpec, path string) (JsonResult, error){
 	content, err := fetchArtifact(test_matrix, path)
 	if err != nil {
 		return nil, err
@@ -113,7 +113,7 @@ func fetchJsonArtifact(test_matrix v1.MatrixSpec, path string) (JsonResult, erro
 	return result, nil
 }
 
-func fetchJsonArrayArtifact(test_matrix v1.MatrixSpec, path string) (JsonArray, error){
+func fetchJsonArrayArtifact(test_matrix *v1.MatrixSpec, path string) (JsonArray, error){
 	content, err := fetchArtifact(test_matrix, path)
 	if err != nil {
 		return nil, err
@@ -128,7 +128,7 @@ func fetchJsonArrayArtifact(test_matrix v1.MatrixSpec, path string) (JsonArray, 
 	return result, nil
 }
 
-func fetchTestResult(test_matrix v1.MatrixSpec, prow_name, build_id, filename string, filetype ArtifactType) (ArtifactResult, error) {
+func fetchTestResult(test_matrix *v1.MatrixSpec, prow_name, build_id, filename string, filetype ArtifactType) (ArtifactResult, error) {
 	file_path := fmt.Sprintf("%s/%s/%s", prow_name, build_id, filename)
 	var result ArtifactResult
 	var err error
@@ -150,7 +150,7 @@ func fetchTestResult(test_matrix v1.MatrixSpec, prow_name, build_id, filename st
 	return result, nil
 }
 
-func FetchLastTestResult(test_matrix v1.MatrixSpec, matrix_name string, test v1.TestSpec, filename string, filetype ArtifactType) (string, ArtifactResult, error) {
+func FetchLastTestResult(test_matrix *v1.MatrixSpec, matrix_name string, test *v1.TestSpec, filename string, filetype ArtifactType) (string, ArtifactResult, error) {
 	last_test_path := fmt.Sprintf("%s/latest-build.txt", test.ProwName)
 	last_test_build_id, err := fetchArtifact(test_matrix, last_test_path)
 	if err != nil {
@@ -180,32 +180,29 @@ func FetchLastTestResult(test_matrix v1.MatrixSpec, matrix_name string, test v1.
 	return string(last_test_build_id), last_test_file, nil
 }
 
-func FetchLastNTestResults(test_matrix v1.MatrixSpec, matrix_name, prow_name string, nb_test int, filename string, filetype ArtifactType) ([]string, map[string]ArtifactResult, error) {
-	test_list_path := fmt.Sprintf("%s/", prow_name)
+func FetchLastNTestResults(test_matrix *v1.MatrixSpec, matrix_name, prow_name string, nb_test int, filename string, filetype ArtifactType) ([]string, map[string]ArtifactResult, error) {
 	test_list_html, err := fetchHtmlArtifact(test_matrix, test_list_path)
 	if err != nil {
 		return nil, nil, fmt.Errorf("error fetching the tests of %s / %s: %v", matrix_name, prow_name, err)
 	}
 
 	test_results := map[string]ArtifactResult{}
-	build_ids := make([]string, 0, nb_test)
 
-	test_list_html.Find("li.grid-row").EachWithBreak(func(i int, s *goquery.Selection) bool {
-		entry_type, found := s.Find("img").Attr("src")
-		if !found || entry_type != "/icons/dir.png" {
-			return true
-		}
-		test_build_id := strings.TrimSuffix(strings.TrimSpace(s.Find("a").Text()), "/")
-		if (!found) {
-			return true
-		}
-
-		build_ids = append([]string{test_build_id}, build_ids...)
-		return true
-	})
-	if len(build_ids) > nb_test {
-		build_ids = build_ids[:nb_test]
+	build_ids, err := listFilesInDirectory(test_list_html, true, false)
+	if err != nil {
+		return nil, nil, fmt.Errorf("error fetching last test results: %v", err)
 	}
+
+	// `build_ids` order is "oldest first" (alphanumeric order of timestamps)
+
+	if len(build_ids) > nb_test {
+		build_ids = build_ids[len(build_ids) - nb_test:]
+	}
+
+	build_ids = reverseStringArray(build_ids)
+
+	// `build_ids` order is now "newest first"
+
 	for _, test_build_id := range build_ids {
 		test_file, err := fetchTestResult(test_matrix, prow_name, test_build_id, filename, filetype)
 		if (err != nil) {
@@ -220,39 +217,27 @@ func FetchLastNTestResults(test_matrix v1.MatrixSpec, matrix_name, prow_name str
 	return build_ids, test_results, err
 }
 
-func FetchTestStepResult(test_matrix v1.MatrixSpec, test_result v1.TestResult, filename string, filetype ArtifactType) (ArtifactResult, error) {
-	step_filenane := fmt.Sprintf("artifacts/%s/%s/%s", test_result.TestSpec.TestName, test_matrix.ProwStep, filename)
-	return fetchTestResult(test_matrix, test_result.TestSpec.ProwName, test_result.BuildId, step_filenane, filetype)
+func FetchTestStepResult(test_matrix *v1.MatrixSpec, test_spec *v1.TestSpec, build_id string, filename string, filetype ArtifactType) (ArtifactResult, error) {
+	step_filenane := fmt.Sprintf("artifacts/%s/%s/%s", test_spec.TestName, test_matrix.ProwStep, filename)
+	return fetchTestResult(test_matrix, test_spec.ProwName, build_id, step_filenane, filetype)
 }
 
-func FetchTestToolboxSteps(test_matrix v1.MatrixSpec, test_result v1.TestResult) ([]string, error) {
-	html_toolbox_steps, err := FetchTestStepResult(test_matrix, test_result, "artifacts/", TypeHtml)
+func FetchTestToolboxSteps(test_matrix *v1.MatrixSpec, test_spec *v1.TestSpec, build_id string) ([]string, error) {
+	html_toolbox_steps, err := FetchTestStepResult(test_matrix, test_spec, build_id, "artifacts/", TypeHtml)
 	if err != nil {
 		return []string{}, err
 	}
 
-	toolbox_steps := []string{}
-	html_toolbox_steps.Html.Find("li.grid-row").EachWithBreak(func(i int, s *goquery.Selection) bool {
-		entry_type, found := s.Find("img").Attr("src")
-
-		if !found || entry_type != "/icons/dir.png" {
-			return true
-		}
-		toolbox_step_name := strings.TrimSuffix(strings.TrimSpace(s.Find("a").Text()), "/")
-		if (!found) {
-			return true
-		}
-
-		toolbox_steps = append([]string{toolbox_step_name}, toolbox_steps...)
-
-		return true
-	})
+	toolbox_steps, err := listFilesInDirectory(html_toolbox_steps.Html, true, false)
+	if err != nil {
+		return []string{}, fmt.Errorf("error fetching toolbox steps: %v", err)
+	}
 
 	return toolbox_steps, nil
 }
 
-func FetchTestToolboxLogs(test_matrix v1.MatrixSpec, test_result v1.TestResult) (map[string]JsonArray, error) {
-	toolbox_steps, err := FetchTestToolboxSteps(test_matrix, test_result)
+func FetchTestToolboxLogs(test_matrix *v1.MatrixSpec, test_spec *v1.TestSpec, build_id string) (map[string]JsonArray, error) {
+	toolbox_steps, err := FetchTestToolboxSteps(test_matrix, test_spec, build_id)
 	if err != nil {
 		fmt.Println(err)
 		return map[string]JsonArray{}, err
@@ -261,14 +246,59 @@ func FetchTestToolboxLogs(test_matrix v1.MatrixSpec, test_result v1.TestResult) 
 
 	for _, toolbox_step := range toolbox_steps {
 		ansible_log_path := "artifacts/"+ toolbox_step + "/_ansible.log.json"
-		json_toolbox_step_logs, err := FetchTestStepResult(test_matrix, test_result, ansible_log_path, TypeJsonArray)
+		json_toolbox_step_logs, err := FetchTestStepResult(test_matrix, test_spec, build_id, ansible_log_path, TypeJsonArray)
 		if err != nil {
 			log.Debugf("No logs for step %s: %v", toolbox_step, err)
-			continue // ignore
+			// no `_ansible.log.json` in the current step, meaning
+			// that this directory wasn't generated by a
+			// toolbox+ansible command. Ignore.
+			continue
 		}
 		logs[toolbox_step] = json_toolbox_step_logs.JsonArray
 		fmt.Println(toolbox_step)
 	}
 
 	return logs, nil
+}
+
+func reverseStringArray(arr []string) []string {
+	for i := 0; i < len(arr)/2; i++ {
+		j := len(arr) - i - 1
+		arr[i], arr[j] = arr[j], arr[i]
+	}
+	return arr
+}
+
+func listFilesInDirectory(html_dir *goquery.Document, dirs_only, files_only bool)([]string, error) {
+	files := []string{}
+
+	html_dir.Find("li.grid-row").EachWithBreak(func(i int, li_tag *goquery.Selection) bool {
+		entry_type, found := li_tag.Find("img").Attr("src")
+
+		if !found {
+			// li-tag doesn't contain an img-tag, this is unexpected
+			// in a directory listing.
+			return true // continue
+		}
+
+		is_dir := entry_type == "/icons/dir.png"
+		if files_only && is_dir || dirs_only && !is_dir {
+			// li-tag is a directory entry, and we don't want directories.
+			// or
+			// li-tag is a file and we don't want files.
+			return true // continue
+		}
+
+		filename := strings.TrimSuffix(strings.TrimSpace(li_tag.Find("a").Text()), "/")
+		if filename == ".." {
+			// skip "parent-dir" entry
+			return true // continue
+		}
+
+		files = append(files, filename)
+
+		return true
+	})
+
+	return files, nil
 }

--- a/pkg/artifacts/fetch.go
+++ b/pkg/artifacts/fetch.go
@@ -219,7 +219,12 @@ func FetchLastNTestResults(test_matrix *v1.MatrixSpec, matrix_name, prow_name st
 }
 
 func FetchTestStepResult(test_matrix *v1.MatrixSpec, test_spec *v1.TestSpec, build_id string, filename string, filetype ArtifactType) (ArtifactResult, error) {
-	step_filenane := fmt.Sprintf("artifacts/%s/%s/%s", test_spec.TestName, test_matrix.ProwStep, filename)
+	var prow_step = test_matrix.ProwStep
+	if test_spec.ProwStep != "" {
+		// override test_matrix.ProwStep if ProwStep is test_spec.ProwStep is specified
+		prow_step = test_spec.ProwStep
+	}
+	step_filenane := fmt.Sprintf("artifacts/%s/%s/%s", test_spec.TestName, prow_step, filename)
 	return fetchTestResult(test_matrix, test_spec.ProwName, build_id, step_filenane, filetype)
 }
 

--- a/pkg/artifacts/fetch.go
+++ b/pkg/artifacts/fetch.go
@@ -189,7 +189,7 @@ func FetchLastNTestResults(test_matrix *v1.MatrixSpec, matrix_name, prow_name st
 
 	test_results := map[string]ArtifactResult{}
 
-	build_ids, err := listFilesInDirectory(test_list_html, true, false)
+	build_ids, err := ListFilesInDirectory(test_list_html, true, false)
 	if err != nil {
 		return nil, nil, fmt.Errorf("error fetching last test results: %v", err)
 	}
@@ -234,7 +234,7 @@ func FetchTestToolboxSteps(test_matrix *v1.MatrixSpec, test_spec *v1.TestSpec, b
 		return []string{}, err
 	}
 
-	toolbox_steps, err := listFilesInDirectory(html_toolbox_steps.Html, true, false)
+	toolbox_steps, err := ListFilesInDirectory(html_toolbox_steps.Html, true, false)
 	if err != nil {
 		return []string{}, fmt.Errorf("error fetching toolbox steps: %v", err)
 	}
@@ -275,7 +275,7 @@ func reverseStringArray(arr []string) []string {
 	return arr
 }
 
-func listFilesInDirectory(html_dir *goquery.Document, dirs_only, files_only bool)([]string, error) {
+func ListFilesInDirectory(html_dir *goquery.Document, dirs_only, files_only bool)([]string, error) {
 	files := []string{}
 
 	html_dir.Find("li.grid-row").EachWithBreak(func(i int, li_tag *goquery.Selection) bool {

--- a/pkg/artifacts/fetch.go
+++ b/pkg/artifacts/fetch.go
@@ -43,6 +43,10 @@ func fetchArtifact(test_matrix v1.MatrixSpec, path string) ([]byte, error) {
 	cache_path := fmt.Sprintf("%s/%s", test_matrix.ArtifactsCache, path)
 	artifact_url := fmt.Sprintf("%s/%s", test_matrix.ArtifactsURL, path)
 
+	if strings.HasSuffix(cache_path, "/") {
+		cache_path += "/?index"
+	}
+
 	content, err := ioutil.ReadFile(cache_path)
 	if err == nil {
 		log.Debugf("File %s found in the cache", artifact_url)
@@ -176,9 +180,8 @@ func FetchLastTestResult(test_matrix v1.MatrixSpec, matrix_name string, test v1.
 	return string(last_test_build_id), last_test_file, nil
 }
 
-
 func FetchLastNTestResults(test_matrix v1.MatrixSpec, matrix_name, prow_name string, nb_test int, filename string, filetype ArtifactType) ([]string, map[string]ArtifactResult, error) {
-	test_list_path := fmt.Sprintf("%s/?index", prow_name)
+	test_list_path := fmt.Sprintf("%s/", prow_name)
 	test_list_html, err := fetchHtmlArtifact(test_matrix, test_list_path)
 	if err != nil {
 		return nil, nil, fmt.Errorf("error fetching the tests of %s / %s: %v", matrix_name, prow_name, err)

--- a/pkg/artifacts/fetch.go
+++ b/pkg/artifacts/fetch.go
@@ -180,7 +180,8 @@ func FetchLastTestResult(test_matrix *v1.MatrixSpec, matrix_name string, test *v
 	return string(last_test_build_id), last_test_file, nil
 }
 
-func FetchLastNTestResults(test_matrix *v1.MatrixSpec, matrix_name, prow_name string, nb_test int, filename string, filetype ArtifactType) ([]string, map[string]ArtifactResult, error) {
+func FetchLastNTestResults(test_matrix *v1.MatrixSpec, matrix_name, prow_name string, test_history int, filename string, filetype ArtifactType) ([]string, map[string]ArtifactResult, error) {
+	test_list_path := fmt.Sprintf("%s/", prow_name)
 	test_list_html, err := fetchHtmlArtifact(test_matrix, test_list_path)
 	if err != nil {
 		return nil, nil, fmt.Errorf("error fetching the tests of %s / %s: %v", matrix_name, prow_name, err)
@@ -195,8 +196,8 @@ func FetchLastNTestResults(test_matrix *v1.MatrixSpec, matrix_name, prow_name st
 
 	// `build_ids` order is "oldest first" (alphanumeric order of timestamps)
 
-	if len(build_ids) > nb_test {
-		build_ids = build_ids[len(build_ids) - nb_test:]
+	if len(build_ids) > test_history {
+		build_ids = build_ids[len(build_ids) - test_history:]
 	}
 
 	build_ids = reverseStringArray(build_ids)

--- a/pkg/artifacts/fetch.go
+++ b/pkg/artifacts/fetch.go
@@ -172,7 +172,7 @@ func FetchLastTestResult(test_matrix v1.MatrixSpec, matrix_name string, test v1.
 	last_test_file, err := fetchTestResult(test_matrix, test.ProwName,
 		string(last_test_build_id), filename, filetype)
 	if (err != nil) {
-		return "", ArtifactResult{}, fmt.Errorf("error fetching the results of the last test of %s:%s (%s): %v",
+		return "", ArtifactResult{}, fmt.Errorf("error fetching the results of the last test of %s: %s (%s): %v",
 			matrix_name, test.ProwName, last_test_build_id, err)
 
 	}

--- a/pkg/template/matrix/tmpl_matrix.go
+++ b/pkg/template/matrix/tmpl_matrix.go
@@ -38,11 +38,11 @@ func Generate(matrixTemplate string, matrices *v1.MatricesSpec, date string) ([]
 			return template.HTML(s)
 		},
         "nb_last_test": func() string {
-			return fmt.Sprintf("%d", matrices.NbTestHistory)
+			return fmt.Sprintf("%d", matrices.TestHistory)
 		},
         "no_test_history": func(test v1.TestSpec) []int {
 			arr := []int{}
-			for i := len(test.OldTests); i < matrices.NbTestHistory; i++ {
+			for i := len(test.OldTests); i < matrices.TestHistory; i++ {
 				arr = append(arr, i)
 			}
 			return arr

--- a/pkg/template/matrix/tmpl_matrix.go
+++ b/pkg/template/matrix/tmpl_matrix.go
@@ -59,8 +59,13 @@ func Generate(matrixTemplate string, matrices *v1.MatricesSpec, date string) ([]
 			if test.TestSpec == nil {
 				return "INVALID"
 			}
+			var prow_step = matrix.ProwStep
+			if test.TestSpec.ProwStep != "" {
+				// override test_matrix.ProwStep if ProwStep is test_spec.ProwStep is specified
+				prow_step = test.TestSpec.ProwStep
+			}
 			return fmt.Sprintf("%s/%s/%s/artifacts/%s/%s",
-				matrix.ArtifactsURL, test.TestSpec.ProwName, test.BuildId, test.TestSpec.TestName, matrix.ProwStep)
+				matrix.ArtifactsURL, test.TestSpec.ProwName, test.BuildId, test.TestSpec.TestName, prow_step)
 		},
 		"spyglass_url": func(matrix v1.MatrixSpec, prowName string, test v1.TestResult) string {
 			return fmt.Sprintf("%s/%s/%s", matrix.ViewerURL, prowName, test.BuildId)

--- a/templates/daily_matrix.mail.tmpl.md
+++ b/templates/daily_matrix.mail.tmpl.md
@@ -9,11 +9,12 @@
 {{ $test_group | group_name | md_subsection}}
 
 {{ range $test := $tests -}}
-{{$test_status := test_status $test.TestResult -}}
+{{ $last_test := (index $test.OldTests 0) }}
+{{$test_status := test_status $last_test -}}
 
-* {{ $matrix.OperatorName }} {{ $test.OperatorVersion }}: {{ $test.Result }}
-  - {{ test_status_descr $test.TestResult $test_status | unescape_html }}
-  - Test finished at {{ $test.FinishDate }}
+* {{ $matrix.OperatorName }} {{ $test.OperatorVersion }}: {{ $last_test.Result }}
+  - {{ test_status_descr $last_test $test_status | unescape_html }}
+  - Test finished at {{ $last_test.FinishDate }}
 
 {{ end }}{{ end }}{{ end }}
 ---

--- a/templates/daily_matrix.tmpl.html
+++ b/templates/daily_matrix.tmpl.html
@@ -140,8 +140,10 @@
                   {{ range $test := $tests }}
                   <tbody>
                     <tr class="changed">
-                      {{ $test_status := test_status $test.TestResult }}
-                      <td class="icon-cell" title="{{ test_status_descr $test.TestResult $test_status }}">
+                      {{ if $test.OldTests }}
+                      {{ $last_test := (index $test.OldTests 0) }}
+                      {{ $test_status := test_status $last_test }}
+                      <td class="icon-cell" title="{{ test_status_descr $last_test $test_status }}">
                         {{ if eq $test_status "success" }}
                         <i class="material-icons state success">check_circle</i>
                         {{ else if eq $test_status "step_success" }}
@@ -166,16 +168,16 @@
 
                       </td>
                       <td class="icon-cell">
-                        {{ if $test.TestResult.TestSpec }}
-                        <a class="mdl-button mdl-js-button mdl-button--icon" href="{{ artifacts_url $matrix $test.TestResult }}/artifacts/"><i class="icon-button material-icons" title="{{ $matrix.OperatorName }} test artifacts">pageview</i></a>
+                        {{ if $last_test.TestSpec }}
+                        <a class="mdl-button mdl-js-button mdl-button--icon" href="{{ artifacts_url $matrix $last_test }}/artifacts/"><i class="icon-button material-icons" title="{{ $matrix.OperatorName }} test artifacts">pageview</i></a>
                         {{ end }}
                       </td>
                       <td class='cell_operator'>{{ $test.OperatorVersion }}</td>
-                      <td class="icon-cell"><a class="mdl-button mdl-js-button mdl-button--icon" href="{{  spyglass_url $matrix $test.ProwName $test.TestResult}}"><i class="icon-button material-icons" title="View test result in Prow">visibility</i></a></td>
+                      <td class="icon-cell"><a class="mdl-button mdl-js-button mdl-button--icon" href="{{  spyglass_url $matrix $test.ProwName $last_test}}"><i class="icon-button material-icons" title="View test result in Prow">visibility</i></a></td>
                       <td></td>
-                      <td><div tabindex="0">
-                          {{ if $test.TestResult.TestSpec }}
-                             {{ $test.FinishDate }}
+                      <td class="date-cell"><div tabindex="0">
+                          {{ if $last_test.TestSpec }}
+                             {{ $last_test.FinishDate }}
                           {{ else }}
                               Test-spec not found.
                           {{ end }}
@@ -201,6 +203,7 @@ OK: {{ $old_test.Ok }}, Failures: {{ $old_test.Failures }}, Ignored: {{ $old_tes
                         <span class="no_old_test no_old_test_{{ $idx}}">&nbsp;&nbsp;&nbsp;&nbsp;</span>
                         {{ end }}
                       </td>
+                      {{ end }}
                     </tr>
                   </tbody>
                   {{ end }}

--- a/templates/daily_matrix.tmpl.html
+++ b/templates/daily_matrix.tmpl.html
@@ -44,6 +44,23 @@
           .old_test_parsing_error {
               background-color: black;
           }
+
+          .test_count_ok {
+              background-color: #DAF7A6;
+          }
+          .test_count_failures {
+              background-color: #ffb7a6;
+          }
+          .test_count_ignored {
+              background-color: #FFC300;
+          }
+
+          .results-cell {
+              width: 150px;
+          }
+          .date-cell {
+              width: 300px;
+          }
         </style>
   </head>
   <body id="index">
@@ -111,7 +128,7 @@
                   <thead>
                     <tr>
                       <th><!-- success/error icon --></th>
-                      <th><!-- build logs --></th>
+                      <th>Ansible tests<!-- test ok/failures/ignored --></th>
                       <th><!-- artifacts dir --></th>
                       <th class='cell_operator'>{{ $matrix.OperatorName }}</th>
                       <th>Prow</th>
@@ -142,11 +159,11 @@
                         <i class="material-icons state pending">watch_later</i>
                         -->
                       </td>
-
-                      <td class="icon-cell">
-                        {{ if $test.TestResult.TestSpec }}
-                        <a class="mdl-button mdl-js-button mdl-button--icon" href="{{ artifacts_url $matrix $test.TestResult }}/build-log.txt"><i class="icon-button material-icons" title="{{ $matrix.OperatorName }} build logs">description</i></a>
+                      <td class="results-cell">
+                        {{ if $test.OldTests }}
+                        <span title="{{ (index $test.OldTests 0).Ok }} Tests OK" class="test_count_ok">&nbsp;{{ (index $test.OldTests 0).Ok }}&nbsp;</span>|<span title="{{ (index $test.OldTests 0).Failures }} Tests Failures" class="test_count_failures">&nbsp;{{ (index $test.OldTests 0).Failures }}&nbsp;</span>{{ if (index $test.OldTests 0).Ignored }}|<span title="{{ (index $test.OldTests 0).Ignored }} Tests Ignored" class="test_count_ignored">&nbsp;{{ (index $test.OldTests 0).Ignored }}&nbsp;</span>{{ end }}
                         {{ end }}
+
                       </td>
                       <td class="icon-cell">
                         {{ if $test.TestResult.TestSpec }}
@@ -166,8 +183,10 @@
                       <td class="old_tests">
                         {{ range $idx, $old_test := $test.OldTests }}
                         {{$old_test_status := test_status $old_test}}
-                        <a title="{{ if eq $idx 0 }}Most recent test: {{ end }}{{ test_status_descr $old_test $old_test_status }}.
-{{ $old_test.FinishDate}}"
+                        <a title="{{ test_status_descr $old_test $old_test_status }}.
+{{ $old_test.FinishDate}}
+OK: {{ $old_test.Ok }}, Failures: {{ $old_test.Failures }}, Ignored: {{ $old_test.Ignored }}
+{{ if eq $idx 0 }}(Most recent test){{ end }}"
                            {{ if ne $old_test_status "step_missing" }}
                            href="{{ artifacts_url $matrix $old_test}}/artifacts"
                            {{ else }}


### PR DESCRIPTION
* 172e94d - Fetch Ansible steps logs and parse OK/Failed/Ignored task count

This commit extends the daily_matrix code to fetch the Ansible JSON
logs of the test steps, whenever they exist.

Example of JSON log file:
https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/logs/periodic-ci-openshift-psap-ci-artifacts-release-4.7-upgrade-gpu-operator-e2e-upgrade-170/1407670009529896960/artifacts/gpu-operator-e2e-upgrade-170/2-postupgrade-gpu-operator-validate-deployment/artifacts/000__gpu-operator__wait_deployment/_ansible.log.json

From these Json logs, we parse the final array entry to extra the
number of tasks which passed (ok), failed or where skipped:
```
{
  "log_level": "info",
  "scope": "playbook",
  "stats": {
    "localhost": {
      "changed": 11,
      "failures": 0,
      "ignored": 0,
      "ok": 14,
      "rescued": 0,
      "skipped": 2,
      "unreachable": 0

  },
  "status": "finished"
}
```

These step counters are aggregated for each each tests, and display on
the HTML template page. For older tests, they are displayed as
tooltips.

---

* a95c320 - Never download "directories", use "/?index" instead


---

* d2a9b60 - Safer parsing from broken `finished.json` and cleanups


---

* 7c265bc - Refactor to remove code duplication

A `TestSpec` used to define a `TestResult` (last test) *and* `OldTests
[]*TestResult`, an array of the test history, including the last test.

Because of this structure duplication, the code for parsing the last
test and the previous one was duplicated.

This PR removes `TestSpec.TestResult` and moves all the `TestResult`
to `OldTests` list.

---

* 7d306b6 - Add env var CI_DASHBOARD_DAILYMATRIX_TEST_HISTORY

This env var overrides the number of tests that will be fetched from
the nightly CI.

Rename `nb_test*` into `test_history` as `nb` (for number) isn't an
English abbreviation :#

---

* 7afa5b6 - Allow overriding test_matrix.ProwStep in test_spec.ProwStep

Most of our tests use `nightly` as test name, and so far this value
was configured once and for all, in the MatrixSpec.
This is the recommended way to proceed.

However, more complex tests require multiple steps, like the GPU
Operator upgrade testing where we have 3 steps.

This commits allows overriding the Prow Step name for each of the
tests. If the field is left empty, the Matrix Prow Step name is used.

---