### PR TITLE
Take into account flakes and expected errors

### DIFF
--- a/api/matrix/v1/spec.go
+++ b/api/matrix/v1/spec.go
@@ -43,6 +43,8 @@ type TestResult struct {
 	StepExecuted bool
 	StepPassed bool
 	StepResult string
+	KnownFlake string
+
 	/* *** */
 	TestSpec *TestSpec
 
@@ -63,6 +65,7 @@ type TestSpec struct {
 	OperatorVersion string `json:"operator_version,omitempty"`
 	Variant string         `json:"variant"`
 	ProwStep string        `json:"prow_step,omitempty"`
+	ExpectedFailures int   `json:"expected_failures"`
 
 	/* *** */
 

--- a/examples/gpu-operator.yml
+++ b/examples/gpu-operator.yml
@@ -19,24 +19,29 @@ matrices:
       - branch: release-4.9
         test_name: gpu-operator-e2e-master
         operator_version: master
+        expected_failures: 3
 
       96_480|OpenShift 4.8:
       - branch: release-4.8
         test_name: gpu-operator-e2e-master
         operator_version: master
+        expected_failures: 3
 
       97_470|OpenShift 4.7:
       - branch: release-4.7
         test_name: gpu-operator-e2e-master
         operator_version: master
+        expected_failures: 3
 
       - branch: release-4.7
         test_name: gpu-operator-e2e-170
         operator_version: 1.7.0
+        expected_failures: 3
 
       - branch: release-4.7
         test_name: gpu-operator-e2e-162
         operator_version: 1.6.2
+        expected_failures: 3
 
       98_475|OpenShift 4.6 upgraded to 4.7:
       - branch: release-4.7
@@ -44,26 +49,32 @@ matrices:
         operator_version: master
         variant: upgrade
         prow_step: 2-postupgrade-gpu-operator-validate-deployment
+        expected_failures: 0
 
       - branch: release-4.7
         test_name: gpu-operator-e2e-upgrade-170
         operator_version: 1.7.0
         variant: upgrade
         prow_step: 2-postupgrade-gpu-operator-validate-deployment
+        expected_failures: 0
 
       99_460|OpenShift 4.6:
       - branch: release-4.6
         test_name: gpu-operator-e2e-170
         operator_version: 1.7.0
+        expected_failures: 3
 
       - branch: release-4.6
         test_name: gpu-operator-e2e-162
         operator_version: 1.6.2
+        expected_failures: 3
 
       - branch: release-4.6
         test_name: gpu-operator-e2e-152
         operator_version: 1.5.2
+        expected_failures: 3
 
       - branch: release-4.6
         test_name: gpu-operator-e2e-140
         operator_version: 1.4.0
+        expected_failures: 3

--- a/examples/nfd.yml
+++ b/examples/nfd.yml
@@ -20,3 +20,4 @@ matrices:
         test_name: operator-e2e-master
         operator_version: 4.8
         variant: nfd
+        expected_failures: 1

--- a/examples/sro.yml
+++ b/examples/sro.yml
@@ -20,9 +20,11 @@ matrices:
         test_name: e2e-master
         operator_version: master
         variant: sro
+        expected_failures: 2
 
       1_470|OpenShift 4.7:
       - branch: release-4.7
         test_name: e2e-master
         operator_version: master
         variant: sro
+        expected_failures: 2

--- a/pkg/populate/populate.go
+++ b/pkg/populate/populate.go
@@ -15,8 +15,6 @@ var log = logrus.New()
 func PopulateTestFromFinished(test *v1.TestResult, test_finished artifacts.ArtifactResult) error {
 	if test_finished.Json["passed"] != nil {
 		test.Passed = test_finished.Json["passed"].(bool)
-	} else {
-		test.Passed = false
 	}
 	if test_finished.Json["result"] != nil {
 		test.Result = test_finished.Json["result"].(string)
@@ -33,14 +31,13 @@ func PopulateTestFromFinished(test *v1.TestResult, test_finished artifacts.Artif
 }
 
 func PopulateTestFromStepFinished(test *v1.TestResult, step_test_finished artifacts.ArtifactResult) error {
-	test.StepExecuted = true
 	if step_test_finished.Json["passed"] != nil {
 		test.StepPassed = step_test_finished.Json["passed"].(bool)
-	} else {
-		test.StepPassed = false
+		test.StepExecuted = true
 	}
 	if step_test_finished.Json["result"] != nil {
 		test.StepResult = step_test_finished.Json["result"].(string)
+		test.StepExecuted = true
 	} else {
 		test.StepResult = "N/A"
 	}
@@ -68,7 +65,11 @@ func PopulateTestFromToolboxLogs(test *v1.TestResult, toolbox_logs map[string]ar
 		test.Failures += failures
 		test.Ignored += ignored
 	}
+
 	log.Debugf("Test: ok %d, failures %d, ignored %d", test.Ok, test.Failures, test.Ignored)
+	if test.Failures >= test.TestSpec.ExpectedFailures {
+		test.Failures -= test.TestSpec.ExpectedFailures
+	}
 
 	return nil
 }

--- a/pkg/template/matrix/tmpl_matrix.go
+++ b/pkg/template/matrix/tmpl_matrix.go
@@ -73,6 +73,8 @@ func Generate(matrixTemplate string, matrices *v1.MatricesSpec, date string) ([]
 		"test_status_descr": func(test v1.TestResult, status string) string {
 			if status == "success" {
 				return "Test passed"
+			} else if status == "known_flake" {
+				return "Test failed because of a known flake: " + test.KnownFlake
 			} else if status == "step_success" {
 				return "Test failed but the operator step passed"
 			} else if status == "step_failed" {
@@ -87,6 +89,8 @@ func Generate(matrixTemplate string, matrices *v1.MatricesSpec, date string) ([]
 		"test_status": func(test v1.TestResult) string {
 			if test.Passed {
 				return "success"
+			} else if test.KnownFlake != "" {
+				return "known_flake"
 			} else if !test.StepExecuted {
 				return "step_missing"
 			} else if test.StepPassed {

--- a/templates/daily_matrix.tmpl.html
+++ b/templates/daily_matrix.tmpl.html
@@ -163,7 +163,7 @@
                       </td>
                       <td class="results-cell">
                         {{ if $test.OldTests }}
-                        <span title="{{ (index $test.OldTests 0).Ok }} Tests OK" class="test_count_ok">&nbsp;{{ (index $test.OldTests 0).Ok }}&nbsp;</span>|<span title="{{ (index $test.OldTests 0).Failures }} Tests Failures" class="test_count_failures">&nbsp;{{ (index $test.OldTests 0).Failures }}&nbsp;</span>{{ if (index $test.OldTests 0).Ignored }}|<span title="{{ (index $test.OldTests 0).Ignored }} Tests Ignored" class="test_count_ignored">&nbsp;{{ (index $test.OldTests 0).Ignored }}&nbsp;</span>{{ end }}
+                        <span title="{{ (index $test.OldTests 0).Ok }} Tests OK" class="test_count_ok">&nbsp;{{ (index $test.OldTests 0).Ok }}&nbsp;</span>{{ if (index $test.OldTests 0).Failures }}|<span title="{{ (index $test.OldTests 0).Failures }} Tests Failures" class="test_count_failures">&nbsp;{{ (index $test.OldTests 0).Failures }}&nbsp;</span>{{ end }}{{ if (index $test.OldTests 0).Ignored }}|<span title="{{ (index $test.OldTests 0).Ignored }} Tests Ignored" class="test_count_ignored">&nbsp;{{ (index $test.OldTests 0).Ignored }}&nbsp;</span>{{ end }}
                         {{ end }}
 
                       </td>

--- a/templates/daily_matrix.tmpl.html
+++ b/templates/daily_matrix.tmpl.html
@@ -41,6 +41,9 @@
           .old_test_step_missing {
               background-color: gray;
           }
+          .old_test_known_flake {
+              background-color: #FFC300;
+          }
           .old_test_parsing_error {
               background-color: black;
           }
@@ -148,6 +151,8 @@
                         <i class="material-icons state success">check_circle</i>
                         {{ else if eq $test_status "step_success" }}
                         <i class="material-icons state success">check_circle</i>
+                        {{ else if eq $test_status "known_flake" }}
+                        <i class="material-icons state known_flake">remove_circle</i>
                         {{ else if eq $test_status "step_failed" }}
                         <i class="material-icons state failure">error</i>
                         {{ else if eq $test_status "step_missing" }}


### PR DESCRIPTION
* `Expected failures` decrease the number of ansible "failures" shown in the dashboard (eg, 3->0 for a passing GPU Operator test)
* `flakes` takes into account the FLAKE flag set during the nightly testing (eg, [this](https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/logs/periodic-ci-openshift-psap-ci-artifacts-release-4.7-gpu-operator-e2e-162/1417982905619058688/artifacts/gpu-operator-e2e-162/nightly/artifacts) test, shown in orange below)
![image](https://user-images.githubusercontent.com/7559202/127819515-2eb6d103-7d0b-4919-89dd-3b31ede9f3d8.png)
