### PR TITLE
Replace 'MISSING' operator/ocp/ci-artifacts version by empty string

### DIFF
--- a/pkg/populate/populate.go
+++ b/pkg/populate/populate.go
@@ -165,6 +165,8 @@ func populateTestResult(test *v1.TestSpec, build_id string, finished_file artifa
 	if strings.Contains(test_result.OpenShiftVersion, "doctype") {
 		// 404 page not recognized
 		test_result.OpenShiftVersion = "[PARSING ERROR]"
+	} else if test_result.OpenShiftVersion == "MISSING" {
+		test_result.OpenShiftVersion = ""
 	}
 
 	operatorVersion_content, err := artifacts.FetchTestStepResult(test_result, "artifacts/operator.version", artifacts.TypeBytes)
@@ -176,6 +178,8 @@ func populateTestResult(test *v1.TestSpec, build_id string, finished_file artifa
 	if strings.Contains(test_result.OperatorVersion, "doctype") {
 		// 404 page not recognized
 		test_result.OperatorVersion = "[PARSING ERROR] " + test_result.TestSpec.OperatorVersion
+	} else if test_result.OperatorVersion == "MISSING" {
+		test_result.OperatorVersion = ""
 	}
 
 	ciartifactsVersion_content, err := artifacts.FetchTestStepResult(test_result, "artifacts/ci_artifact.git_version", artifacts.TypeBytes)
@@ -187,6 +191,8 @@ func populateTestResult(test *v1.TestSpec, build_id string, finished_file artifa
 	if strings.Contains(test_result.CiArtifactsVersion, "doctype") {
 		// 404 page not recognized
 		test_result.CiArtifactsVersion = "PARSING ERROR"
+	} else if test_result.CiArtifactsVersion == "MISSING" {
+		test_result.CiArtifactsVersion = ""
 	}
 	return test_result
 }


### PR DESCRIPTION
Switching from this (**Operator version** column)
![old view](https://user-images.githubusercontent.com/7559202/133570820-784fe94e-52a6-40bf-9367-728ad4eaa4cb.png)
to this
![new view](https://user-images.githubusercontent.com/7559202/133570800-d9ff0666-3d4f-403d-88e2-156d3b166df5.png)


