### PR TITLE
Track pre-submit jobs

### DIFF
--- a/examples/gpu-operator.yml
+++ b/examples/gpu-operator.yml
@@ -107,3 +107,70 @@ matrices:
           test_name: nvidia-gpu-operator-e2e-master
           operator_version: master
           variant: "4.18"
+
+  3_presubmit:
+    description: Red Hat OpenShift Pre-submit
+    operator_name: GPU Operator
+    viewer_url: https://prow.ci.openshift.org/view/gs/origin-ci-test/logs
+    artifacts_url: https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/logs
+    artifacts_cache: cache
+    repository_url: https://github.com/rh-ecosystem-edge/nvidia-ci
+    prow_config: pull-ci-rh-ecosystem-edge-nvidia-ci
+    prow_step: gpu-operator-e2e
+    tests:
+
+      70_412|OpenShift 4.12:
+      - branch: main
+        test_name: nvidia-gpu-operator-e2e-24-6-x
+        operator_version: "24.6"
+        variant: "4.12"
+      - branch: main
+        test_name: nvidia-gpu-operator-e2e-24-9-x
+        operator_version: "24.9"
+        variant: "4.12"
+      - branch: main
+        test_name: nvidia-gpu-operator-e2e-master
+        operator_version: master
+        variant: "4.12"
+
+      70_414|OpenShift 4.14:
+      - branch: main
+        test_name: nvidia-gpu-operator-e2e-24-6-x
+        operator_version: "24.6"
+        variant: "4.14"
+      - branch: main
+        test_name: nvidia-gpu-operator-e2e-24-9-x
+        operator_version: "24.9"
+        variant: "4.14"
+      - branch: main
+        test_name: nvidia-gpu-operator-e2e-master
+        operator_version: master
+        variant: "4.14"
+
+      70_415|OpenShift 4.15:
+      - branch: main
+        test_name: nvidia-gpu-operator-e2e-24-6-x
+        operator_version: "24.6"
+        variant: "4.15"
+      - branch: main
+        test_name: nvidia-gpu-operator-e2e-24-9-x
+        operator_version: "24.9"
+        variant: "4.15"
+      - branch: main
+        test_name: nvidia-gpu-operator-e2e-master
+        operator_version: master
+        variant: "4.15"
+
+      70_418|OpenShift 4.18:
+        - branch: main
+          test_name: nvidia-gpu-operator-e2e-24-6-x
+          operator_version: "24.6"
+          variant: "4.18"
+        - branch: main
+          test_name: nvidia-gpu-operator-e2e-24-9-x
+          operator_version: "24.9"
+          variant: "4.18"
+        - branch: main
+          test_name: nvidia-gpu-operator-e2e-master
+          operator_version: master
+          variant: "4.18"


### PR DESCRIPTION
Track pre-submit jobs as a preparation for on-demand running on OpenShift stable and RC, triggered by version changes.