### PR TITLE
changing schedule 4.16, 4.18

### DIFF
--- a/examples/gpu-operator.yml
+++ b/examples/gpu-operator.yml
@@ -109,6 +109,20 @@ matrices:
         operator_version: master
         variant: "4.15"
 
+      81_419|OpenShift 4.19 - Weekly:
+      - branch: main
+        test_name: nvidia-gpu-operator-e2e-24-6-x
+        operator_version: "24.6"
+        variant: "4.19"
+      - branch: main
+        test_name: nvidia-gpu-operator-e2e-24-9-x
+        operator_version: "24.9"
+        variant: "4.19"
+      - branch: main
+        test_name: nvidia-gpu-operator-e2e-master
+        operator_version: master
+        variant: "4.19"
+
   3_presubmit:
     description: Red Hat OpenShift Pre-submit
     operator_name: GPU Operator
@@ -203,3 +217,17 @@ matrices:
           test_name: nvidia-gpu-operator-e2e-master
           operator_version: master
           variant: "4.18"
+
+      70_419|OpenShift 4.19 pre-submit:
+        - branch: main
+          test_name: nvidia-gpu-operator-e2e-24-6-x
+          operator_version: "24.6"
+          variant: "4.19"
+        - branch: main
+          test_name: nvidia-gpu-operator-e2e-24-9-x
+          operator_version: "24.9"
+          variant: "4.19"
+        - branch: main
+          test_name: nvidia-gpu-operator-e2e-master
+          operator_version: master
+          variant: "4.19"

--- a/examples/gpu-operator.yml
+++ b/examples/gpu-operator.yml
@@ -14,19 +14,20 @@ matrices:
     prow_step: gpu-operator-e2e
     tests:
 
-      90_416|OpenShift 4.16 - Nightly:
+      90_418|OpenShift 4.18 - Nightly:
       - branch: main
         test_name: nvidia-gpu-operator-e2e-24-6-x
         operator_version: "24.6"
-        variant: "4.16"
+        variant: "4.18"
       - branch: main
         test_name: nvidia-gpu-operator-e2e-24-9-x
         operator_version: "24.9"
-        variant: "4.16"
+        variant: "4.18"
       - branch: main
         test_name: nvidia-gpu-operator-e2e-master
         operator_version: master
-        variant: "4.16"
+        variant: "4.18"
+
       90_417|OpenShift 4.17 - Nightly:
       - branch: main
         test_name: nvidia-gpu-operator-e2e-24-6-x
@@ -51,6 +52,20 @@ matrices:
     prow_config: periodic-ci-rh-ecosystem-edge-nvidia-ci
     prow_step: gpu-operator-e2e
     tests:
+
+      81_416|OpenShift 4.16 - Weekly:
+        - branch: main
+          test_name: nvidia-gpu-operator-e2e-24-6-x
+          operator_version: "24.6"
+          variant: "4.16"
+        - branch: main
+          test_name: nvidia-gpu-operator-e2e-24-9-x
+          operator_version: "24.9"
+          variant: "4.16"
+        - branch: main
+          test_name: nvidia-gpu-operator-e2e-master
+          operator_version: master
+          variant: "4.16"
 
       81_412|OpenShift 4.12 - Weekly:
       - branch: main
@@ -93,20 +108,6 @@ matrices:
         test_name: nvidia-gpu-operator-e2e-master
         operator_version: master
         variant: "4.15"
-
-      81_418|OpenShift 4.18 - Weekly:
-        - branch: main
-          test_name: nvidia-gpu-operator-e2e-24-6-x
-          operator_version: "24.6"
-          variant: "4.18"
-        - branch: main
-          test_name: nvidia-gpu-operator-e2e-24-9-x
-          operator_version: "24.9"
-          variant: "4.18"
-        - branch: main
-          test_name: nvidia-gpu-operator-e2e-master
-          operator_version: master
-          variant: "4.18"
 
   3_presubmit:
     description: Red Hat OpenShift Pre-submit


### PR DESCRIPTION
Due to the release of 4.18 we should change the schedule of the jbos for 4.16 and 4.18.

---

/cc @empovit 